### PR TITLE
Add credits roll to about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -37,130 +37,102 @@ layout: default
   <div class="credits-section">
     <h2>Credits Roll</h2>
     <p>Software I've built or helped build since 2007.</p>
-
-    <details>
-      <summary><strong>2025</strong></summary>
-      <ul>
-        <li><a href="https://www.ecue.ai/">Ecue</a> - AI Agent migration</li>
-        <li><a href="https://app.opening.guru/">Opening Guru</a> - End-to-end chess app</li>
-        <li><a href="https://quadrantstrategies.com/">Quadrant Strategies</a> - Panelist Platform</li>
-        <li><a href="https://vuenome.com/">VueNome</a> - AI Agent Build</li>
-        <li><a href="https://myhyde.com/uni/my-career-closet/">Hyde MCC Career Fair</a> - Technical Leadership, AI Recommender</li>
-        <li><a href="https://www.hivewealth.com/">Hive Wealth</a> - Technical Leadership</li>
-        <li><a href="https://brize.ai/">Brize</a> - End-to-end AI MVP</li>
-        <li><a href="https://app.thrippy.fun/">ThriftShop/Thrippy</a> - End-to-end AI MVP</li>
-        <li><a href="https://gopursue.com/">GoPursue</a> - End-to-end AI MVP</li>
-        <li><a href="https://www.projectbasta.com/">Project Basta</a> - V2 Rebuild Scoring Algorithm</li>
-      </ul>
-    </details>
-
-    <details>
-      <summary><strong>2024</strong></summary>
-      <ul>
-        <li><a href="https://www.darksaberlabs.com/">DarkSaber</a> - Tech Leadership, Edge AI, Radio</li>
-        <li><a href="https://puttrax.com/">Puttrax</a> - Tech Leadership, Hardware, ML</li>
-        <li>Billflow for <a href="https://www.penningtonpartners.co/">Pennington Partners</a> - Internal Tool</li>
-        <li><a href="https://www.barometerxp.com/">Barometer XP</a> - Games Platform</li>
-        <li><a href="https://www.experiolabs.ai/">Experio</a> - Tech Leadership, AI Architecture</li>
-        <li><a href="https://data4living.com/">Data4Living</a> - Tech Leadership, Patent Application</li>
-        <li><a href="https://start.markshhc.com/">Marks Home Care</a> - Tech Leadership</li>
-        <li><a href="https://www.equati.ai/">Equati</a> - Tech Leadership, Software Architecture</li>
-        <li><a href="https://www.delvedeeper.ai/">Delve</a> - Embeddings/LLM, Ingest Scalability</li>
-        <li><a href="https://acuity.health/">Acuity Health</a> - HealthIndex, Transformer/LLM Research</li>
-        <li><a href="https://www.arclet.com/">Arclet</a> - Fractional CTO</li>
-        <li><a href="https://thedinnerdaily.com/">Dinner Daily</a> - Fractional CTO</li>
-      </ul>
-    </details>
-
-    <details>
-      <summary><strong>2023</strong></summary>
-      <ul>
-        <li><a href="https://www.capitalpride.org/">Capital Pride App</a> - Load Testing & Architecture</li>
-        <li>Lexx - Engineering Plan, Recommender System, UX Redesign</li>
-        <li>Alignment View - 360-degree Video Processing, ThreeJS</li>
-        <li><a href="https://www.projectbasta.com/">Project Basta</a> - Student/Job Match Scoring</li>
-        <li><a href="https://www.manual.care/">Manual</a> - Video Encoding and Transcription Pipeline</li>
-        <li>Julep - Tech Leadership, React Native</li>
-        <li><a href="https://spurlocal.org">SpurLocal</a> - Site Rebrand</li>
-        <li><a href="https://www.airtechnologiesinc.com/">Air Technologies</a> - Discovery, Architecture</li>
-        <li>VueNome - Discovery, Architecture</li>
-      </ul>
-    </details>
-
-    <details>
-      <summary><strong>2022</strong></summary>
-      <ul>
-        <li><a href="https://storyraise.com">Yearly Report / Storyraise</a> - App Rebuild</li>
-        <li>Worthy Mentoring 2.0 - React Native CI/CD Pipeline</li>
-        <li><a href="https://squirreledu.co/">Squirrel</a> - Financial Literacy Video Game</li>
-        <li>Swoopt - Ticket Syncing Service</li>
-        <li><a href="https://www.bysavi.com/">Savi</a> - API Proxy & Webhooks Service</li>
-        <li>uand2 - Two-sided market + Network Visualization</li>
-      </ul>
-    </details>
-
-    <details>
-      <summary><strong>2019-2021</strong></summary>
-      <ul>
-        <li><a href="https://www.joinpropio.com/">NanEd/Propio</a> - Technical Management</li>
-        <li><a href="https://www.bysavi.com/">Savi</a> - Application Errors Analysis (ML)</li>
-        <li><a href="https://office.thinknimble.com/">The ThinkNimble Office</a> - Unity HTML5 Experiment</li>
-        <li>Antique Stories - React Native, In-App Purchases</li>
-        <li><a href="https://lightenarrangements.com/">Lighten</a> - Staff Portal, Album Manager</li>
-        <li><a href="https://workwithcanary.com/">Canary</a> - Hardship Loans Platform</li>
-        <li><a href="https://github.com/thinknimble/tn-models-fp">tn-models</a> - JavaScript API patterns library</li>
-        <li><a href="https://glowmode.com/">Glowmode</a> - React Native + In-App Purchases</li>
-        <li>Changeroots - React Native Candidate Comparison</li>
-        <li><a href="https://github.com/thinknimble/tn-bootstrapper">tn-bootstrapper</a> - Project scaffolding tool</li>
-        <li><a href="https://www.bysavi.com/">Savi</a> - Plaid Integration, Loan Calculator, PSLF Calculator</li>
-        <li><a href="https://www.spotandtango.com/">Spot & Tango</a> - Animated Marketing Website, Subscription Service</li>
-        <li><a href="https://www.leadmn.org/">LeadMN</a> - React Native App & Backend</li>
-        <li><a href="https://hopeforhenry.org/">Hope for Henry</a> - Survey Video Game</li>
-        <li><a href="https://www.edsights.io/">EdSights</a> - VueJS + Django App, Infrastructure</li>
-        <li>Dressmate - Clothing Resale Platform</li>
-        <li>Imby - Matching Algorithm</li>
-      </ul>
-    </details>
-
-    <details>
-      <summary><strong>2017-2018</strong></summary>
-      <ul>
-        <li>Festi - React Native Mobile App</li>
-        <li>CFP - Legacy PHP Site, Board Match, Learning Commons</li>
-        <li>Givebutter - Quickbooks and Lob Integrations</li>
-        <li>Soil Nerd - Soil Analysis Calculator</li>
-        <li>TopKnott - Two-sided marketplace</li>
-        <li>FACE Addiction - WordPress Website</li>
-        <li>AllowIt / ClassPulse - React Native + FullStack</li>
-        <li>Ordway - Salesforce.com Integration</li>
-        <li>Park City Giving Guide - Holiday Donations Platform</li>
-      </ul>
-    </details>
-
-    <details>
-      <summary><strong>2014-2017: Aspire</strong></summary>
-      <ul>
-        <li>Aspire - Co-Founded, built from 0 to $2M ARR, acquired</li>
-        <li>Operations Management Dashboard</li>
-        <li>QBO Integration, Automated Invoicing</li>
-        <li>Recommendation Algorithm (item-to-item collaborative filtering)</li>
-        <li>Team Perks Platform</li>
-        <li>Personal Perks Platform</li>
-      </ul>
-    </details>
-
-    <details>
-      <summary><strong>2007-2013: Early Career</strong></summary>
-      <ul>
-        <li>Lucierna Redesign & Integration - A SmartBear acquisition</li>
-        <li>AlertSite UX Redesign / AngularJS Build</li>
-        <li><a href="https://modavanti.com">Modavanti.com</a> - E-commerce for sustainable fashion</li>
-        <li>Compass Connect Social Network</li>
-        <li>Compass Mentor Training Platform</li>
-        <li>A New Leaf - Subscription e-commerce</li>
-        <li>Fabretto - PHP Site</li>
-      </ul>
-    </details>
+    <ul>
+      <li>2025 <a href="https://www.ecue.ai/">Ecue</a> - AI Agent migration</li>
+      <li>2025 <a href="https://app.opening.guru/">Opening Guru</a> - End-to-end chess app</li>
+      <li>2025 <a href="https://quadrantstrategies.com/">Quadrant Strategies</a> - Panelist Platform</li>
+      <li>2025 <a href="https://vuenome.com/">VueNome</a> - AI Agent Build</li>
+      <li>2025 <a href="https://myhyde.com/uni/my-career-closet/">Hyde MCC Career Fair</a> - Technical Leadership, AI Recommender</li>
+      <li>2025 <a href="https://www.hivewealth.com/">Hive Wealth</a> - Technical Leadership</li>
+      <li>2025 <a href="https://brize.ai/">Brize</a> - End-to-end AI MVP</li>
+      <li>2025 <a href="https://app.thrippy.fun/">ThriftShop/Thrippy</a> - End-to-end AI MVP</li>
+      <li>2025 <a href="https://gopursue.com/">GoPursue</a> - End-to-end AI MVP</li>
+      <li>2025 <a href="https://www.projectbasta.com/">Project Basta</a> - V2 Rebuild Scoring Algorithm</li>
+      <li>2024-26 <a href="https://www.darksaberlabs.com/">DarkSaber</a> - Tech Leadership, Project Leadership, Radio</li>
+      <li>2024-25 <a href="https://puttrax.com/">Puttrax</a> - Tech Leadership, Hardware, ML</li>
+      <li>2024-25 Billflow for <a href="https://www.penningtonpartners.co/">Pennington Partners</a> - Internal Tool</li>
+      <li>2024 <a href="https://www.barometerxp.com/">Barometer XP</a> - Games Platform</li>
+      <li>2024 <a href="https://www.experiolabs.ai/">Experio</a> - Tech Leadership, AI Architecture</li>
+      <li>2024 <a href="https://data4living.com/">Data4Living</a> - Tech Leadership, Patent Application</li>
+      <li>2024 <a href="https://start.markshhc.com/">Marks Home Care</a> - Tech Leadership</li>
+      <li>2024 <a href="https://www.equati.ai/">Equati</a> - Tech Leadership, Software Architecture</li>
+      <li>2024 <a href="https://www.delvedeeper.ai/">Delve</a> - Embeddings/LLM, Ingest Scalability</li>
+      <li>2024 <a href="https://acuity.health/">Acuity Health</a> - HealthIndex, Transformer/LLM Research</li>
+      <li>2024 <a href="https://www.arclet.com/">Arclet</a> - Fractional CTO</li>
+      <li>2024 <a href="https://thedinnerdaily.com/">Dinner Daily</a> - Fractional CTO</li>
+      <li>2024 Brumby Horse - Supported FastAI Weight Prediction Model</li>
+      <li>2024 Limitless 3D Prints - Tech Leadership</li>
+      <li>2024-2026 <a href="https://github.com/thinknimble/tn-cli">TN CLI</a></li>
+      <li>2023-24 <a href="https://www.capitalpride.org/">Capital Pride App</a> - Load Testing & Architecture</li>
+      <li>2023-24 Lexx - Engineering Plan, Recommender System, UX Redesign</li>
+      <li>2023 Alignment View - 360-degree Video Processing, ThreeJS</li>
+      <li>2023 <a href="https://www.projectbasta.com/">Project Basta</a> - Student/Job Match Scoring</li>
+      <li>2023 <a href="https://www.manual.care/">Manual</a> - Video Encoding and Transcription Pipeline</li>
+      <li>2023 <a href="https://thedinnerdaily.com/">Dinner Daily</a> - Maintenance and Migration Plan</li>
+      <li>2023 Julep - Tech Leadership, React Native</li>
+      <li>2023 <a href="https://spurlocal.org">SpurLocal</a> - Site Rebrand</li>
+      <li>2023 <a href="https://www.airtechnologiesinc.com/">Air Technologies</a> - Discovery, Architecture</li>
+      <li>2023 VueNome - Discovery, Architecture</li>
+      <li>2022 <a href="https://storyraise.com">Yearly Report / Storyraise</a> - App Rebuild</li>
+      <li>2022 Worthy Mentoring 2.0 - React Native CI/CD Pipeline</li>
+      <li>2022 <a href="https://squirreledu.co/">Squirrel</a> - Financial Literacy Video Game</li>
+      <li>2022 Swoopt - Ticket Syncing Service</li>
+      <li>2022 <a href="https://www.bysavi.com/">Savi</a> - API Proxy & Webhooks Service</li>
+      <li>2022 uand2 - Two-sided market + Network Visualization</li>
+      <li>2021 <a href="https://www.joinpropio.com/">NanEd/Propio</a> - Technical Management</li>
+      <li>2021 <a href="https://www.bysavi.com/">Savi</a> - Application Errors Analysis (ML)</li>
+      <li>2020 <a href="https://office.thinknimble.com/">The ThinkNimble Office</a> - Unity HTML5 Experiment</li>
+      <li>2020 Antique Stories - React Native, In-App Purchases</li>
+      <li>2020 <a href="https://lightenarrangements.com/">Lighten</a> - Staff Portal, Album Manager</li>
+      <li>2020 <a href="https://workwithcanary.com/">Canary</a> - Hardship Loans Platform</li>
+      <li>2020 <a href="https://github.com/thinknimble/tn-models-fp">tn-models</a> - JavaScript API patterns library</li>
+      <li>2020 <a href="https://github.com/thinknimble/tn-utils">tn-utils</a> - JavaScript utilities library</li>
+      <li>2020 <a href="https://github.com/thinknimble/tn-harvester">tn-reports, tn-harvester</a> - Internal reporting tool</li>
+      <li>2020 YIA Event Hub - Pandemic virtual conference platform</li>
+      <li>2020 <a href="https://glowmode.com/">Glowmode</a> - React Native + In-App Purchases</li>
+      <li>2019 Changeroots - React Native Candidate Comparison</li>
+      <li>2019 <a href="https://github.com/thinknimble/tn-bootstrapper">tn-bootstrapper</a> v1.0</li>
+      <li>2019 <a href="https://www.bysavi.com/">Savi</a> - Plaid Integration</li>
+      <li>2019 <a href="https://www.bysavi.com/">Savi</a> - Loan Repayments Calculator</li>
+      <li>2019 <a href="https://www.bysavi.com/">Savi</a> - PSLF Calculator</li>
+      <li>2019 <a href="https://www.spotandtango.com/">Spot & Tango</a> - Unkibble Animated Marketing Website</li>
+      <li>2019 <a href="https://www.spotandtango.com/">Spot & Tango</a> - Subscription Calculator & Service</li>
+      <li>2019 <a href="https://www.leadmn.org/">LeadMN</a> - React Native App & Backend</li>
+      <li>2019 Here to Career - React Native App & Backend</li>
+      <li>2019 <a href="https://hopeforhenry.org/">Hope for Henry</a> - Survey Video Game</li>
+      <li>2019 <a href="https://www.edsights.io/">EdSights</a> - VueJS + Django App, Infrastructure</li>
+      <li>2019 Dressmate - Clothing Resale Platform</li>
+      <li>2019 Imby - Matching Algorithm</li>
+      <li>2018 Festi - React Native Mobile App</li>
+      <li>2018 Pact Survey</li>
+      <li>2018 CFP - Legacy PHP Site</li>
+      <li>2018 CFP - Board Match Site</li>
+      <li>2018 Givebutter - Quickbooks and Lob Integrations</li>
+      <li>2018 CFP - Learning Commons Site</li>
+      <li>2018 Soil Nerd - Soil Analysis Calculator</li>
+      <li>2018 TopKnott - Two-sided marketplace</li>
+      <li>2017 FACE Addiction Website - WordPress</li>
+      <li>2017 AllowIt / ClassPulse - React Native + FullStack</li>
+      <li>2017 Ordway - Salesforce.com Integration</li>
+      <li>2017 tn-marketing - First version of ThinkNimble's marketing site</li>
+      <li>2017 Eastern Senior Highschool - WordPress</li>
+      <li>2017 Park City Giving Guide - Holiday Donations Platform</li>
+      <li>2017 Aspire - Operations Management Dashboard</li>
+      <li>2017 Aspire - QBO Integration, Automated Invoicing & Bookkeeping</li>
+      <li>2016 Aspire - Recommendation Algorithm</li>
+      <li>2015 Aspire - Team Perks Platform</li>
+      <li>2014 Alert! Alert! npm Package</li>
+      <li>2014 Aspire - Personal Perks Platform (Co-Founded, scaled to $2M ARR, acquired)</li>
+      <li>2014 Lucierna Redesign & Integration - A SmartBear acquisition</li>
+      <li>2013 AlertSite UX Redesign / AngularJS Build</li>
+      <li>2012 <a href="https://modavanti.com">Modavanti.com</a> - E-commerce for sustainable fashion</li>
+      <li>2011 Compass Connect Social Network</li>
+      <li>2011 Compass Mentor Training Platform</li>
+      <li>2010 Compass WordPress-based Website</li>
+      <li>2009 Compass Flash-based Website</li>
+      <li>2008 A New Leaf - Subscription e-commerce</li>
+      <li>2007 Fabretto - PHP Site</li>
+    </ul>
   </div>
 
   <div class="four-thousand-weeks">

--- a/about.html
+++ b/about.html
@@ -33,7 +33,136 @@ layout: default
     <strong>Github</strong>
     <a href="https://github.com/whusterj">whusterj</a>
   </p>
-  
+
+  <div class="credits-section">
+    <h2>Credits Roll</h2>
+    <p>Software I've built or helped build since 2007.</p>
+
+    <details>
+      <summary><strong>2025</strong></summary>
+      <ul>
+        <li><a href="https://www.ecue.ai/">Ecue</a> - AI Agent migration</li>
+        <li><a href="https://app.opening.guru/">Opening Guru</a> - End-to-end chess app</li>
+        <li><a href="https://quadrantstrategies.com/">Quadrant Strategies</a> - Panelist Platform</li>
+        <li><a href="https://vuenome.com/">VueNome</a> - AI Agent Build</li>
+        <li><a href="https://myhyde.com/uni/my-career-closet/">Hyde MCC Career Fair</a> - Technical Leadership, AI Recommender</li>
+        <li><a href="https://www.hivewealth.com/">Hive Wealth</a> - Technical Leadership</li>
+        <li><a href="https://brize.ai/">Brize</a> - End-to-end AI MVP</li>
+        <li><a href="https://app.thrippy.fun/">ThriftShop/Thrippy</a> - End-to-end AI MVP</li>
+        <li><a href="https://gopursue.com/">GoPursue</a> - End-to-end AI MVP</li>
+        <li><a href="https://www.projectbasta.com/">Project Basta</a> - V2 Rebuild Scoring Algorithm</li>
+      </ul>
+    </details>
+
+    <details>
+      <summary><strong>2024</strong></summary>
+      <ul>
+        <li><a href="https://www.darksaberlabs.com/">DarkSaber</a> - Tech Leadership, Edge AI, Radio</li>
+        <li><a href="https://puttrax.com/">Puttrax</a> - Tech Leadership, Hardware, ML</li>
+        <li>Billflow for <a href="https://www.penningtonpartners.co/">Pennington Partners</a> - Internal Tool</li>
+        <li><a href="https://www.barometerxp.com/">Barometer XP</a> - Games Platform</li>
+        <li><a href="https://www.experiolabs.ai/">Experio</a> - Tech Leadership, AI Architecture</li>
+        <li><a href="https://data4living.com/">Data4Living</a> - Tech Leadership, Patent Application</li>
+        <li><a href="https://start.markshhc.com/">Marks Home Care</a> - Tech Leadership</li>
+        <li><a href="https://www.equati.ai/">Equati</a> - Tech Leadership, Software Architecture</li>
+        <li><a href="https://www.delvedeeper.ai/">Delve</a> - Embeddings/LLM, Ingest Scalability</li>
+        <li><a href="https://acuity.health/">Acuity Health</a> - HealthIndex, Transformer/LLM Research</li>
+        <li><a href="https://www.arclet.com/">Arclet</a> - Fractional CTO</li>
+        <li><a href="https://thedinnerdaily.com/">Dinner Daily</a> - Fractional CTO</li>
+      </ul>
+    </details>
+
+    <details>
+      <summary><strong>2023</strong></summary>
+      <ul>
+        <li><a href="https://www.capitalpride.org/">Capital Pride App</a> - Load Testing & Architecture</li>
+        <li>Lexx - Engineering Plan, Recommender System, UX Redesign</li>
+        <li>Alignment View - 360-degree Video Processing, ThreeJS</li>
+        <li><a href="https://www.projectbasta.com/">Project Basta</a> - Student/Job Match Scoring</li>
+        <li><a href="https://www.manual.care/">Manual</a> - Video Encoding and Transcription Pipeline</li>
+        <li>Julep - Tech Leadership, React Native</li>
+        <li><a href="https://spurlocal.org">SpurLocal</a> - Site Rebrand</li>
+        <li><a href="https://www.airtechnologiesinc.com/">Air Technologies</a> - Discovery, Architecture</li>
+        <li>VueNome - Discovery, Architecture</li>
+      </ul>
+    </details>
+
+    <details>
+      <summary><strong>2022</strong></summary>
+      <ul>
+        <li><a href="https://storyraise.com">Yearly Report / Storyraise</a> - App Rebuild</li>
+        <li>Worthy Mentoring 2.0 - React Native CI/CD Pipeline</li>
+        <li><a href="https://squirreledu.co/">Squirrel</a> - Financial Literacy Video Game</li>
+        <li>Swoopt - Ticket Syncing Service</li>
+        <li><a href="https://www.bysavi.com/">Savi</a> - API Proxy & Webhooks Service</li>
+        <li>uand2 - Two-sided market + Network Visualization</li>
+      </ul>
+    </details>
+
+    <details>
+      <summary><strong>2019-2021</strong></summary>
+      <ul>
+        <li><a href="https://www.joinpropio.com/">NanEd/Propio</a> - Technical Management</li>
+        <li><a href="https://www.bysavi.com/">Savi</a> - Application Errors Analysis (ML)</li>
+        <li><a href="https://office.thinknimble.com/">The ThinkNimble Office</a> - Unity HTML5 Experiment</li>
+        <li>Antique Stories - React Native, In-App Purchases</li>
+        <li><a href="https://lightenarrangements.com/">Lighten</a> - Staff Portal, Album Manager</li>
+        <li><a href="https://workwithcanary.com/">Canary</a> - Hardship Loans Platform</li>
+        <li><a href="https://github.com/thinknimble/tn-models-fp">tn-models</a> - JavaScript API patterns library</li>
+        <li><a href="https://glowmode.com/">Glowmode</a> - React Native + In-App Purchases</li>
+        <li>Changeroots - React Native Candidate Comparison</li>
+        <li><a href="https://github.com/thinknimble/tn-bootstrapper">tn-bootstrapper</a> - Project scaffolding tool</li>
+        <li><a href="https://www.bysavi.com/">Savi</a> - Plaid Integration, Loan Calculator, PSLF Calculator</li>
+        <li><a href="https://www.spotandtango.com/">Spot & Tango</a> - Animated Marketing Website, Subscription Service</li>
+        <li><a href="https://www.leadmn.org/">LeadMN</a> - React Native App & Backend</li>
+        <li><a href="https://hopeforhenry.org/">Hope for Henry</a> - Survey Video Game</li>
+        <li><a href="https://www.edsights.io/">EdSights</a> - VueJS + Django App, Infrastructure</li>
+        <li>Dressmate - Clothing Resale Platform</li>
+        <li>Imby - Matching Algorithm</li>
+      </ul>
+    </details>
+
+    <details>
+      <summary><strong>2017-2018</strong></summary>
+      <ul>
+        <li>Festi - React Native Mobile App</li>
+        <li>CFP - Legacy PHP Site, Board Match, Learning Commons</li>
+        <li>Givebutter - Quickbooks and Lob Integrations</li>
+        <li>Soil Nerd - Soil Analysis Calculator</li>
+        <li>TopKnott - Two-sided marketplace</li>
+        <li>FACE Addiction - WordPress Website</li>
+        <li>AllowIt / ClassPulse - React Native + FullStack</li>
+        <li>Ordway - Salesforce.com Integration</li>
+        <li>Park City Giving Guide - Holiday Donations Platform</li>
+      </ul>
+    </details>
+
+    <details>
+      <summary><strong>2014-2017: Aspire</strong></summary>
+      <ul>
+        <li>Aspire - Co-Founded, built from 0 to $2M ARR, acquired</li>
+        <li>Operations Management Dashboard</li>
+        <li>QBO Integration, Automated Invoicing</li>
+        <li>Recommendation Algorithm (item-to-item collaborative filtering)</li>
+        <li>Team Perks Platform</li>
+        <li>Personal Perks Platform</li>
+      </ul>
+    </details>
+
+    <details>
+      <summary><strong>2007-2013: Early Career</strong></summary>
+      <ul>
+        <li>Lucierna Redesign & Integration - A SmartBear acquisition</li>
+        <li>AlertSite UX Redesign / AngularJS Build</li>
+        <li><a href="https://modavanti.com">Modavanti.com</a> - E-commerce for sustainable fashion</li>
+        <li>Compass Connect Social Network</li>
+        <li>Compass Mentor Training Platform</li>
+        <li>A New Leaf - Subscription e-commerce</li>
+        <li>Fabretto - PHP Site</li>
+      </ul>
+    </details>
+  </div>
+
   <div class="four-thousand-weeks">
     <h2>My 4000 Weeks</h2>
     <p>Born September 24, 1987</p>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -241,6 +241,29 @@ ul li {
   font-weight: 300;
 }
 
+/* Credits Section */
+.credits-section {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+.credits-section h2 {
+  margin-bottom: 0.5rem;
+}
+.credits-section details {
+  margin-bottom: 0.5rem;
+}
+.credits-section summary {
+  cursor: pointer;
+  padding: 0.3rem 0;
+}
+.credits-section ul {
+  margin: 0.5rem 0 0.5rem 1.5rem;
+  padding: 0;
+}
+.credits-section li {
+  margin-bottom: 0.3rem;
+}
+
 /* Post Styles */
 .post-preview {
   padding: 1rem 0.5rem;


### PR DESCRIPTION
## Summary
- Adds a "Credits Roll" section to the about page listing software projects since 2007
- Flat chronological list format with year prefixes and links to live projects
- Styles added to main CSS file

## Preview
Check the about page after deploy to see the credits section.